### PR TITLE
Added config option to hide Content field

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ See [Elemental modules by Dynamic](https://github.com/orgs/dynamic/repositories?
 
 ## Configuration
 
+To hide the Content field:
+
+```yml
+Dynamic\Elements\Embedded\Elements\ElementEmbeddedCode:
+    hide_content_field: true
+```
+
 See [SilverStripe Elemental Configuration](https://github.com/silverstripe/silverstripe-elemental#configuration)
 
 ## Translations

--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ See [Elemental modules by Dynamic](https://github.com/orgs/dynamic/repositories?
 To hide the Content field:
 
 ```yml
+---
+After:
+  - "#silverstripeelemental-embedded-codeconfig"
+---
 Dynamic\Elements\Embedded\Elements\ElementEmbeddedCode:
-    hide_content_field: true
+  hide_content_field: true
 ```
 
 See [SilverStripe Elemental Configuration](https://github.com/silverstripe/silverstripe-elemental#configuration)

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,3 +1,5 @@
 ---
 Name: silverstripeelemental-embedded-codeconfig
 ---
+Dynamic\Elements\Embedded\Elements\ElementEmbeddedCode:
+  hide_content_field: false

--- a/src/Elements/ElementEmbeddedCode.php
+++ b/src/Elements/ElementEmbeddedCode.php
@@ -54,6 +54,10 @@ class ElementEmbeddedCode extends BaseElement
                 ->setTitle('Embed Code')
         );
 
+        if (ElementEmbeddedCode::config()->get('hide_content_field')) {
+            $fields->removeByName('Content');
+        }
+
         return $fields;
     }
 


### PR DESCRIPTION
Personally, I prefer my blocks simpler and more modular, so have added a config option to hide the [recently added](https://github.com/dynamic/silverstripe-elemental-embedded-code/pull/14) Content field.

````yml
Dynamic\Elements\Embedded\Elements\ElementEmbeddedCode:
  hide_content_field: true
````