### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/src/Elements/ElementEmbeddedCode.php
+++ b/src/Elements/ElementEmbeddedCode.php
@@ -20,12 +20,12 @@ class ElementEmbeddedCode extends BaseElement
     /**
      * @var string
      */
-    private static $singular_name = 'Embedded Code Element';
+    private static $singular_name = 'Embedded Code';
 
     /**
      * @var string
      */
-    private static $plural_name = 'Embedded Code Elements';
+    private static $plural_name = 'Embedded Code Blocks';
 
     private static $description = 'Embed code like iFrames or Javascript on a page.';
 
@@ -55,14 +55,6 @@ class ElementEmbeddedCode extends BaseElement
         );
 
         return $fields;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__.'.BlockType', 'Embedded Code');
     }
 
     /**


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementEmbeddedCode`
- Updated `$singular_name` from `'Embedded Code Element'` to `'Embedded Code'`
- Updated `$plural_name` from `'Embedded Code Elements'` to `'Embedded Code Blocks'`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #19

Related: dynamic/silverstripe-essentials-tools#68