### PR TITLE
feat: Silverstripe 6 compatibility (4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A block to embed code like iFrames or Javascript on a page
 
 ## Requirements
 
-* silverstripe/recipe-cms: ^5
-* dnadesign/silverstripe-elemental: ^5
+* silverstripe/recipe-cms: ^6
+* dnadesign/silverstripe-elemental: ^6
 
 ## Installation
 

--- a/_config.php
+++ b/_config.php
@@ -1,4 +1,3 @@
 <?php
 
-define('SILVERSTRIPE_ELEMENTAL-EMBEDDED-CODE_PATH', __DIR__);
-define('SILVERSTRIPE_ELEMENTAL-EMBEDDED-CODE_DIR', basename(__DIR__));
+// no-op

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,12 @@
         }
     ],
     "require": {
-        "dnadesign/silverstripe-elemental": "^5",
-        "silverstripe/framework": "^5"
+        "dnadesign/silverstripe-elemental": "^6",
+        "silverstripe/framework": "^6",
+        "silverstripe/vendor-plugin": "^3"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -45,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "4.x-dev"
         }
     },
     "scripts": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
+         colors="true">
     <testsuites>
         <testsuite name="elemental-embedded-code">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 5 support. This is a new major version (4.0) requiring Silverstripe 6 only.

## Changes

- **composer.json**: `framework ^6`, `elemental ^6`, `vendor-plugin ^3`
- **require-dev**: `recipe-testing ^4`
- **branch-alias**: `4.x-dev`
- **phpunit.xml.dist**: Update to PHPUnit 11 format (`source/include` replaces deprecated `filter/whitelist`)
- **_config.php**: Remove deprecated `define()` constants
- **README.md**: Update requirements to Silverstripe 6
- **CI**: Add SS6 test matrix with PHP 8.3

## Version History

| Version | Silverstripe |
|---------|-------------|
| 4.x     | ^6          |
| 3.x     | ^5          |
| 2.x     | ^4          |
