### PR TITLE
fix: escape PSR-4 backslashes in composer.json autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {
-            "Dynamic\Elements\Embedded\": "src/",
-            "Dynamic\Elements\Embedded\Tests\": "tests/"
+            "Dynamic\\Elements\\Embedded\\": "src/",
+            "Dynamic\\Elements\\Embedded\\Tests\\": "tests/"
         }
     },
     "config": {


### PR DESCRIPTION
## Problem
The `chore: fix branch alias dev-master -> dev-4` commit edited `composer.json` and accidentally un-escaped the PSR-4 namespace keys (`\\` → `\`), producing invalid JSON. This crashes `silverstripe/gha-generate-matrix` (exit 255), so CI on branch `4` fails in ~17s before any job runs.

## Fix
Restore the escaped backslashes in `autoload.psr-4`, matching the valid content already shipped in tag `4.0.0`. The `branch-alias` change (`dev-4: 4.x-dev`) from that commit is correct and is kept.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)