### PR TITLE
feat: add hide_content_field config to ElementEmbeddedCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ See [Elemental modules by Dynamic](https://github.com/orgs/dynamic/repositories?
 
 ## Configuration
 
+To hide the `Content` field (leaving only the embed code field), set `hide_content_field`:
+
+```yml
+---
+After:
+  - '#silverstripeelemental-embedded-codeconfig'
+---
+Dynamic\Elements\Embedded\Elements\ElementEmbeddedCode:
+  hide_content_field: true
+```
+
 See [SilverStripe Elemental Configuration](https://github.com/silverstripe/silverstripe-elemental#configuration)
 
 ## Translations

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,3 +1,5 @@
 ---
 Name: silverstripeelemental-embedded-codeconfig
 ---
+Dynamic\Elements\Embedded\Elements\ElementEmbeddedCode:
+  hide_content_field: false

--- a/src/Elements/ElementEmbeddedCode.php
+++ b/src/Elements/ElementEmbeddedCode.php
@@ -54,6 +54,10 @@ class ElementEmbeddedCode extends BaseElement
                 ->setTitle('Embed Code')
         );
 
+        if (static::config()->get('hide_content_field')) {
+            $fields->removeByName('Content');
+        }
+
         return $fields;
     }
 


### PR DESCRIPTION
## Summary

Adds a `hide_content_field` config flag (default `false`) that removes the `Content` field from the `ElementEmbeddedCode` CMS edit form, leaving only the embed code field.

This reimplements #15 (which targeted the deprecated `master` branch and used a hardcoded `ElementEmbeddedCode::config()`) on the active `4` branch, using `static::config()` so subclasses can override the flag via late static binding.

## Usage

```yml
---
After:
  - '#silverstripeelemental-embedded-codeconfig'
---
Dynamic\Elements\Embedded\Elements\ElementEmbeddedCode:
  hide_content_field: true
```

Replaces #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)